### PR TITLE
Fix main page layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -227,17 +227,17 @@ function App() {
   }, [messages.length]);
 
   return (
-    <main>
+    <main style={{ height: "100dvh", display: "flex", flexDirection: "column" }}>
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <Header />
         <Paper
           elevation={3}
           sx={{
-            width: "1400px",
-            height: "700px",
-            m: "10px auto",
-            pb: "100px",
+            // width: "1400px",
+            // height: "700px",
+            flexGrow: 1,
+            m: 2,
             position: "relative",
             display: "flex",
             justifyContent: "center",


### PR DESCRIPTION
- 絶対値でのwidth/heightの設定はできるだけ避けたほうが良いです！難しい判断かと思いますが、必要に迫られた場合は使用して良いかと思います。
- 代わりに flex-grow: 1 を使うことで残りの高さを埋めることができます

![127 0 0 1_5173_ (1)](https://github.com/ohayo-u/zoominfo-clone/assets/25846438/8fca196b-ad05-48cb-a5ca-441990e050c0)
